### PR TITLE
Provide function to get db.uri or db.uris from the config

### DIFF
--- a/src/main/scala/com/dataintuitive/luciusapi/initialize.scala
+++ b/src/main/scala/com/dataintuitive/luciusapi/initialize.scala
@@ -39,7 +39,7 @@ object initialize extends SparkSessionJob with NamedObjectSupport {
                         runtime: JobEnvironment,
                         config: Config): JobData Or Every[ValidationProblem] = {
 
-    val db = paramDbs(config)
+    val db = paramDbOrDbs(config)
     val genes = paramGenes(config)
     val dbVersion = paramDbVersion(config)
     val partitions = paramPartitions(config)


### PR DESCRIPTION
Testing with 
- only db.uri
- only db.uris
- both db.uri and db.uris
- neither db.uri or db.uris

resulted in the expected behaviour when trying to load spark servers

[loading_multiple_dbs.txt](https://github.com/data-intuitive/LuciusAPI/files/7363114/loading_multiple_dbs.txt)