### PR TITLE
Use new LuciusCore version 4.0.9 and bump own version number

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "LuciusAPI"
 
 import aether.AetherKeys._
 
-version in ThisBuild := "5.0.0-alpha6"
+version in ThisBuild := "5.0.0-alpha7"
 
 scalaVersion := "2.11.12"
 
@@ -10,7 +10,7 @@ resolvers += Resolver.githubPackages("data-intuitive")
 resolvers += "Artifactory" at "https://sparkjobserver.jfrog.io/artifactory/jobserver/"
 
 libraryDependencies ++= Seq(
-  "com.data-intuitive" %% "luciuscore"        % "4.0.8",
+  "com.data-intuitive" %% "luciuscore"        % "4.0.9",
   "spark.jobserver"    %% "job-server-api"    % "0.11.1"     % "provided",
   "spark.jobserver"    %% "job-server-extras" % "0.11.1"     % "provided",
   "org.scalactic"      %% "scalactic"         % "3.0.7"      % "test"    ,


### PR DESCRIPTION
Changes in LuciusCore:
- added dose and time units in replies
- rename fields in flatDb for statistics (protocol -> cell, compound -> treatment, concentration -> dose)
