### PR TITLE
Add multiplicity parameter for artificial increase of data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "LuciusAPI"
 
 import aether.AetherKeys._
 
-ThisBuild / version := "5.1.3"
+ThisBuild / version := "5.1.4-alpha"
 
 scalaVersion := "2.11.12"
 

--- a/src/main/scala/com/dataintuitive/luciusapi/Common.scala
+++ b/src/main/scala/com/dataintuitive/luciusapi/Common.scala
@@ -312,6 +312,11 @@ object Common extends Serializable {
         .getOrElse(Map.empty)
     }
 
+    /**
+     * In order to make sure Lucius handles heavy load and slow response times,
+     * it's important to dev/test with larger datasets than a small dev dataset allows.
+     * This paramter multiplies input data this many times so the apparant dataset is larger.
+     */
     def paramMultiplicity(config: Config):Int = {
       Try(config.getString("multiplicity").toInt)
         .getOrElse(1)

--- a/src/main/scala/com/dataintuitive/luciusapi/Common.scala
+++ b/src/main/scala/com/dataintuitive/luciusapi/Common.scala
@@ -312,6 +312,11 @@ object Common extends Serializable {
         .getOrElse(Map.empty)
     }
 
+    def paramMultiplicity(config: Config):Int = {
+      Try(config.getString("multiplicity").toInt)
+        .getOrElse(1)
+    }
+
   }
 
 }

--- a/src/main/scala/com/dataintuitive/luciusapi/initialize.scala
+++ b/src/main/scala/com/dataintuitive/luciusapi/initialize.scala
@@ -96,10 +96,6 @@ object initialize extends SparkSessionJob with NamedObjectSupport {
 
     val thisVersion = state.state.filter(_.version.major.toString == majorVersion)
 
-    println(outputs)
-    println(state)
-    println(thisVersion)
-
     val parquets = thisVersion.map(_.obj.toString).map(
       sparkSession.read
         .schema(Encoders.product[Perturbation].schema) // This assists parquet file reading so that it is more independent of our current Perturbation format.


### PR DESCRIPTION
In order to experiment with ComPass under heavy load, we allow for duplicating the data `N` times where `N` can be configured using the `multiplicity` parameter provided during initialisation of the API.